### PR TITLE
Client exclude

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -405,9 +405,16 @@ class backuppc::client (
 
     file { "${system_home_directory}/.ssh":
       ensure  => $directory_ensure,
-      mode   => '0700',
-      owner  => $system_account,
-      group  => $system_account,
+      mode    => '0700',
+      owner   => $system_account,
+      group   => $system_account,
+    }
+
+    file { "${system_home_directory}/.ssh/known_hosts":
+      ensure  => 'link',
+      target  => '/dev/null',
+      force   => 'true',
+      require => File["${system_home_directory}/.ssh"],
     }
 
     file { "${system_home_directory}/backuppc.sh":

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -404,7 +404,7 @@ class backuppc::client (
     }
 
     file { "${system_home_directory}/.ssh":
-      ensure => $directory_ensure,
+      ensure  => $directory_ensure,
       mode   => '0700',
       owner  => $system_account,
       group  => $system_account,
@@ -420,17 +420,19 @@ class backuppc::client (
     }
 
     Ssh_authorized_key <<| tag == "backuppc_${backuppc_hostname}" |>> {
+      ensure  => $ensure,
       user    => $system_account,
       require => File["${system_home_directory}/.ssh"]
     }
 
     file { "/etc/ssh/ssh_keys/${system_account}.pub":
-      ensure  => present,
+      ensure  => $ensure,
       owner   => $system_account,
       mode    => "0600",
       require => User[$system_account],
     } ->
     Ssh_authorized_key <<| tag == "backuppc_${backuppc_hostname}" |>> {
+      ensure  => $ensure,
       target  => "/etc/ssh/ssh_keys/${system_account}.pub"
     }
 

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -413,6 +413,12 @@ class backuppc::server (
 
     'topdir_ssh':
       path => "${real_topdir}/.ssh",;
+
+    'topdir_ssh_known_hosts':
+      path   => "${real_topdir}/.ssh/known_hosts",
+      ensure => 'link',
+      target => '/dev/null',
+      force  => 'true';
   }
 
   # Workaround for client exported resources that are


### PR DESCRIPTION
update client.pp to ensure => absent properly
update client/server to set BACKUP/.ssh/known_hosts to /dev/null to force the use of the system puppet managed /etc/ssh/known_hosts